### PR TITLE
Added batching support to GroupingProjection.

### DIFF
--- a/IDeliverable.Utils.Core.Tests/GroupingProjectionTest.cs
+++ b/IDeliverable.Utils.Core.Tests/GroupingProjectionTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
@@ -340,6 +340,27 @@ namespace IDeliverable.Utils.Core.Tests
 
             Assert.IsFalse(mTarget[0].Items.Contains(happeningToChange));
             Assert.IsTrue(collectionRemoveEventRaised);
+        }
+
+        [TestMethod]
+        [Description("Adding a new item with a new group value does not raise the appropriate events when BeginUpdate is called. Only when EndUpdate is called.")]
+        public void BatchChangeTest01()
+        {
+            var groupCollectionAddEventRaised = false;
+            var newTime = new DateTime(2017, 01, 03, 12, 00, 00);
+            var newName = "HappeningDay3@12";
+
+            mTarget.CollectionChanged += (sender, e) =>
+            {
+                groupCollectionAddEventRaised = true;
+            };
+
+            mTarget.BeginUpdate();
+            mSourceCollection.Add(new Happening(newTime, newName));
+
+            Assert.IsFalse(groupCollectionAddEventRaised);
+            mTarget.EndUpdate();
+            Assert.IsTrue(groupCollectionAddEventRaised);
         }
 
         private class Happening : INotifyPropertyChanged

--- a/IDeliverable.Utils.Core.Tests/GroupingProjectionTest.cs
+++ b/IDeliverable.Utils.Core.Tests/GroupingProjectionTest.cs
@@ -343,24 +343,33 @@ namespace IDeliverable.Utils.Core.Tests
         }
 
         [TestMethod]
-        [Description("Adding a new item with a new group value does not raise the appropriate events when BeginUpdate is called. Only when EndUpdate is called.")]
-        public void BatchChangeTest01()
+        [Description("Adding a new item with a new group value does not raise any events within a BeginUpdate/EndUpdate block, but raises a collection reset event on EndUpdate.")]
+        public void ChangeTest12()
         {
+            var groupCollectionAnyEventRaised = false;
             var groupCollectionAddEventRaised = false;
+            var groupCollectionResetEventRaised = false;
             var newTime = new DateTime(2017, 01, 03, 12, 00, 00);
             var newName = "HappeningDay3@12";
 
             mTarget.CollectionChanged += (sender, e) =>
             {
-                groupCollectionAddEventRaised = true;
+                groupCollectionAnyEventRaised = true;
+                groupCollectionAddEventRaised = e.Action == NotifyCollectionChangedAction.Add;
+                groupCollectionResetEventRaised = e.Action == NotifyCollectionChangedAction.Reset;
             };
 
             mTarget.BeginUpdate();
+
             mSourceCollection.Add(new Happening(newTime, newName));
 
-            Assert.IsFalse(groupCollectionAddEventRaised);
+            Assert.IsFalse(groupCollectionAnyEventRaised);
+
             mTarget.EndUpdate();
-            Assert.IsTrue(groupCollectionAddEventRaised);
+
+            Assert.IsTrue(groupCollectionAnyEventRaised);
+            Assert.IsFalse(groupCollectionAddEventRaised);
+            Assert.IsTrue(groupCollectionResetEventRaised);
         }
 
         private class Happening : INotifyPropertyChanged

--- a/IDeliverable.Utils.Core/Collections/GroupingProjection.cs
+++ b/IDeliverable.Utils.Core/Collections/GroupingProjection.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -9,7 +9,7 @@ using IDeliverable.Utils.Core.CollectionExtensions;
 
 namespace IDeliverable.Utils.Core.Collections
 {
-    public partial class GroupingProjection<TGroupKey, TOrderKey, TItem> : ObservableCollection<GroupingProjection<TGroupKey, TOrderKey, TItem>.Group>, IDisposable
+    public partial class GroupingProjection<TGroupKey, TOrderKey, TItem> : BatchingCollection<GroupingProjection<TGroupKey, TOrderKey, TItem>.Group>, IDisposable
         where TOrderKey : IComparable<TOrderKey>
     {
         public GroupingProjection(IEnumerable<TItem> sourceCollection, Func<TItem, TGroupKey> groupKeySelector)

--- a/IDeliverable.Utils.Core/Collections/GroupingProjection.cs
+++ b/IDeliverable.Utils.Core/Collections/GroupingProjection.cs
@@ -157,7 +157,7 @@ namespace IDeliverable.Utils.Core.Collections
                     AddEventHandlersToGroups(newGroups);
                     break;
                 case NotifyCollectionChangedAction.Reset:
-                    RemoveEventHandlersFromGroups(oldGroups); // TODO: Is this really correct?
+                    RemoveEventHandlersFromGroups(oldGroups);
                     AddEventHandlersToGroups(newGroups);
                     break;
             }
@@ -223,12 +223,18 @@ namespace IDeliverable.Utils.Core.Collections
 
         private void AddEventHandlersToGroups(IEnumerable<Group> groups)
         {
+            if (groups == null)
+                return;
+
             foreach (var g in groups)
                 ((INotifyCollectionChanged)g.Items).CollectionChanged += GroupItems_CollectionChanged;
         }
 
         private void RemoveEventHandlersFromGroups(IEnumerable<Group> groups)
         {
+            if (groups == null)
+                return;
+            
             foreach (var g in groups)
                 ((INotifyCollectionChanged)g.Items).CollectionChanged -= GroupItems_CollectionChanged;
         }


### PR DESCRIPTION
This PR adds batching support to `GroupingProjection` by having `GroupingProjection` inherit from `BatchingCollection`.

Unit test included.