### PR TITLE
Adds overload of Handler registration to allow instance to be retrieved from IServiceProvider

### DIFF
--- a/IDeliverable.Utils.Core/Handlers/ServiceCollectionExtensions.cs
+++ b/IDeliverable.Utils.Core/Handlers/ServiceCollectionExtensions.cs
@@ -33,6 +33,19 @@ namespace Microsoft.Extensions.DependencyInjection
             return services;
         }
 
+        public static IServiceCollection AddHandler<TService>(this IServiceCollection services, Func<IServiceProvider, TService> implementationFactory) where TService : class
+        {
+            foreach (var implementedInterface in typeof(TService).GetInterfaces())
+            {
+                if (implementedInterface.IsConstructedGenericType && implementedInterface.GetGenericTypeDefinition() == typeof(IHandler<>))
+                {
+                    _ = services.AddSingleton(implementedInterface, implementationFactory);
+                }
+            }
+
+            return services;
+        }
+
         public static IServiceCollection AddHandler<TMessage>(this IServiceCollection services, Action<TMessage> handler)
         {
             var delegateHandler = new DelegateHandler<TMessage>(handler);


### PR DESCRIPTION
Note: this is a breaking change as it could potentially add ambiguity to existing usages of `AddHandler` (as shown in the unit tests)