### PR TITLE
Handlers registrations improvements (idempotency, single instance for multiple message types)

### DIFF
--- a/IDeliverable.Utils.Core.Tests/HandlersTest.cs
+++ b/IDeliverable.Utils.Core.Tests/HandlersTest.cs
@@ -300,6 +300,62 @@ namespace IDeliverable.Utils.Core.Tests
             Assert.AreEqual(expected: 1, handlers.Count());
         }
 
+		[TestMethod]
+        [Description("Same handler implementation instance is used to handle multiple message types (instance registration).")]
+        public void HandlersTest15()
+        {
+			var handler = new TestDualHandler();
+
+            var serviceProvider =
+                new ServiceCollection()
+                    .AddHandler(handler)
+                    .BuildServiceProvider();
+
+            var handler1 = serviceProvider.GetRequiredService<IHandler<Message1>>();
+			var handler2 = serviceProvider.GetRequiredService<IHandler<Message2>>();
+
+            Assert.AreSame<object>(handler1, handler2);
+        }
+
+		[TestMethod]
+        [Description("Same handler implementation instance is used to handle multiple message types (type registration).")]
+        public void HandlersTest16()
+        {
+            var serviceProvider =
+                new ServiceCollection()
+                    .AddHandler<TestDualHandler>()
+                    .BuildServiceProvider();
+
+            var handler1 = serviceProvider.GetRequiredService<IHandler<Message1>>();
+			var handler2 = serviceProvider.GetRequiredService<IHandler<Message2>>();
+
+            Assert.AreSame<object>(handler1, handler2);
+        }
+
+		[TestMethod]
+        [Description("Handler implementation factory is called once per handled message type.")]
+        public void HandlersTest17()
+        {
+			var numInvocations = 0;
+
+			TestDualHandler handlerFactory(IServiceProvider serviceProvider)
+			{
+				numInvocations++;
+				return new();
+			}
+
+            var serviceProvider =
+                new ServiceCollection()
+                    .AddHandler(handlerFactory)
+                    .BuildServiceProvider();
+
+            var handler1 = serviceProvider.GetRequiredService<IHandler<Message1>>();
+			var handler2 = serviceProvider.GetRequiredService<IHandler<Message2>>();
+
+			Assert.AreEqual(expected: 2, numInvocations);
+            Assert.AreNotSame<object>(handler1, handler2);
+        }
+
         public class TestMessage
         {
             public TestMessage(string value)

--- a/IDeliverable.Utils.Core.Tests/HandlersTest.cs
+++ b/IDeliverable.Utils.Core.Tests/HandlersTest.cs
@@ -32,9 +32,28 @@ namespace IDeliverable.Utils.Core.Tests
             Assert.AreEqual(value, handler.HandledMessage.Value);
         }
 
-        [TestMethod]
-        [Description("Registration using handler type definition.")]
+		[TestMethod]
+        [Description("Registration using handler implementation factory.")]
         public void HandlersTest02()
+        {
+            var serviceProvider =
+                new ServiceCollection()
+                    .AddHandler(implementationFactory: serviceProvider => new TestHandler<TestMessage>())
+                    .AddSingleton<TestSender>()
+                    .BuildServiceProvider();
+
+            var value = Guid.NewGuid().ToString();
+            var handler = (TestHandler<TestMessage>)serviceProvider.GetRequiredService<IHandler<TestMessage>>();
+            var sender = serviceProvider.GetRequiredService<TestSender>();
+            sender.Send(value);
+
+            Assert.IsNotNull(handler.HandledMessage);
+            Assert.AreEqual(value, handler.HandledMessage.Value);
+        }
+
+        [TestMethod]
+        [Description("Registration using handler implementation type.")]
+        public void HandlersTest03()
         {
             var serviceProvider =
                 new ServiceCollection()
@@ -53,7 +72,7 @@ namespace IDeliverable.Utils.Core.Tests
 
         [TestMethod]
         [Description("Registration using sync delegate handler.")]
-        public void HandlersTest03()
+        public void HandlersTest04()
         {
             TestMessage handledMessage = null;
 
@@ -73,7 +92,7 @@ namespace IDeliverable.Utils.Core.Tests
 
         [TestMethod]
         [Description("Registration using async delegate handler.")]
-        public void HandlersTest04()
+        public void HandlersTest05()
         {
             TestMessage handledMessage = null;
             
@@ -97,7 +116,7 @@ namespace IDeliverable.Utils.Core.Tests
 
         [TestMethod]
         [Description("Registration of multiple handlers of same message type.")]
-        public void HandlersTest05()
+        public void HandlersTest06()
         {
             TestMessage handledMessageByOne = null;
             TestMessage handledMessageByOther = null;
@@ -121,7 +140,7 @@ namespace IDeliverable.Utils.Core.Tests
 
         [TestMethod]
         [Description("Resolution of multiple handlers of same message type.")]
-        public void HandlersTest06()
+        public void HandlersTest07()
         {
             TestMessage handledMessageByOne = null;
             TestMessage handledMessageByOther = null;
@@ -140,7 +159,7 @@ namespace IDeliverable.Utils.Core.Tests
 
         [TestMethod]
         [Description("Exception in first handler stops execution and propagates to sender.")]
-        public void HandlersTest07()
+        public void HandlersTest08()
         {
             TestMessage handledMessageByOne = null;
             TestMessage handledMessageByOther = null;
@@ -176,7 +195,7 @@ namespace IDeliverable.Utils.Core.Tests
 
         [TestMethod]
         [Description("Exception in first handler does not stop execution when ignoreExceptions argument is set to true.")]
-        public void HandlersTest08()
+        public void HandlersTest09()
         {
             TestMessage handledMessageByOne = null;
             TestMessage handledMessageByOther = null;
@@ -202,7 +221,7 @@ namespace IDeliverable.Utils.Core.Tests
 
         [TestMethod]
         [Description("Sender works even if no handlers are registered.")]
-        public void HandlersTest09()
+        public void HandlersTest10()
         {
             var serviceProvider =
                 new ServiceCollection()
@@ -218,7 +237,7 @@ namespace IDeliverable.Utils.Core.Tests
         [DataRow(true)]
         [DataRow(false)]
         [Description("Cancellation exceptions are always thrown.")]
-        public void HandlersTest10(bool ignoreExceptions)
+        public void HandlersTest11(bool ignoreExceptions)
         {
             var serviceProvider =
                 new ServiceCollection()
@@ -232,23 +251,53 @@ namespace IDeliverable.Utils.Core.Tests
             Assert.ThrowsException<OperationCanceledException>(() => sender.Send(value, ignoreExceptions));
         }
 
+		[TestMethod]
+        [Description("Registration using handler implementation instance is idempotent.")]
+        public void HandlersTest12()
+        {
+			var handler = new TestHandler<TestMessage>();
+
+            var serviceProvider =
+                new ServiceCollection()
+                    .AddHandler(handler)
+                    .AddHandler(handler)
+                    .BuildServiceProvider();
+
+            var handlers = serviceProvider.GetRequiredService<IEnumerable<IHandler<TestMessage>>>();
+
+            Assert.AreEqual(expected: 1, handlers.Count());
+        }
+
+		[TestMethod]
+        [Description("Registration using handler implementation factory is idempotent.")]
+        public void HandlersTest13()
+        {
+            static TestHandler<TestMessage> handlerFactory(IServiceProvider serviceProvider) => new();
+
+            var serviceProvider =
+                new ServiceCollection()
+                    .AddHandler(handlerFactory)
+                    .AddHandler(handlerFactory)
+                    .BuildServiceProvider();
+
+            var handlers = serviceProvider.GetRequiredService<IEnumerable<IHandler<TestMessage>>>();
+
+            Assert.AreEqual(expected: 1, handlers.Count());
+        }
+
         [TestMethod]
-        [Description("Registration using handler implementation factory.")]
-        public void HandlersTest11()
+        [Description("Registration using handler implementation type is idempotent.")]
+        public void HandlersTest14()
         {
             var serviceProvider =
                 new ServiceCollection()
-                    .AddHandler(implementationFactory: serviceProvider => new TestHandler<TestMessage>())
-                    .AddSingleton<TestSender>()
+                    .AddHandler<TestHandler<TestMessage>>()
+					.AddHandler<TestHandler<TestMessage>>()
                     .BuildServiceProvider();
 
-            var value = Guid.NewGuid().ToString();
-            var handler = (TestHandler<TestMessage>)serviceProvider.GetRequiredService<IHandler<TestMessage>>();
-            var sender = serviceProvider.GetRequiredService<TestSender>();
-            sender.Send(value);
+            var handlers = serviceProvider.GetRequiredService<IEnumerable<IHandler<TestMessage>>>();
 
-            Assert.IsNotNull(handler.HandledMessage);
-            Assert.AreEqual(value, handler.HandledMessage.Value);
+            Assert.AreEqual(expected: 1, handlers.Count());
         }
 
         public class TestMessage
@@ -293,5 +342,26 @@ namespace IDeliverable.Utils.Core.Tests
                 }
             }
         }
+
+		public class TestDualHandler : IHandler<Message1>, IHandler<Message2>
+        {
+            public Message1 HandledMessage1 { get; private set; }
+			public Message2 HandledMessage2 { get; private set; }
+
+            public Task HandleAsync(Message1 message, CancellationToken cancellationToken)
+            {
+                HandledMessage1 = message;
+                return Task.CompletedTask;
+            }
+
+            public Task HandleAsync(Message2 message, CancellationToken cancellationToken)
+            {
+                HandledMessage2 = message;
+                return Task.CompletedTask;
+            }
+        }
+
+		public class Message1 { }
+		public class Message2 { }
     }
 }

--- a/IDeliverable.Utils.Core.Tests/HandlersTest.cs
+++ b/IDeliverable.Utils.Core.Tests/HandlersTest.cs
@@ -32,7 +32,7 @@ namespace IDeliverable.Utils.Core.Tests
             Assert.AreEqual(value, handler.HandledMessage.Value);
         }
 
-		[TestMethod]
+        [TestMethod]
         [Description("Registration using handler implementation factory.")]
         public void HandlersTest02()
         {
@@ -251,11 +251,11 @@ namespace IDeliverable.Utils.Core.Tests
             Assert.ThrowsException<OperationCanceledException>(() => sender.Send(value, ignoreExceptions));
         }
 
-		[TestMethod]
+        [TestMethod]
         [Description("Registration using handler implementation instance is idempotent.")]
         public void HandlersTest12()
         {
-			var handler = new TestHandler<TestMessage>();
+            var handler = new TestHandler<TestMessage>();
 
             var serviceProvider =
                 new ServiceCollection()
@@ -268,7 +268,7 @@ namespace IDeliverable.Utils.Core.Tests
             Assert.AreEqual(expected: 1, handlers.Count());
         }
 
-		[TestMethod]
+        [TestMethod]
         [Description("Registration using handler implementation factory is idempotent.")]
         public void HandlersTest13()
         {
@@ -292,7 +292,7 @@ namespace IDeliverable.Utils.Core.Tests
             var serviceProvider =
                 new ServiceCollection()
                     .AddHandler<TestHandler<TestMessage>>()
-					.AddHandler<TestHandler<TestMessage>>()
+                    .AddHandler<TestHandler<TestMessage>>()
                     .BuildServiceProvider();
 
             var handlers = serviceProvider.GetRequiredService<IEnumerable<IHandler<TestMessage>>>();
@@ -300,11 +300,11 @@ namespace IDeliverable.Utils.Core.Tests
             Assert.AreEqual(expected: 1, handlers.Count());
         }
 
-		[TestMethod]
+        [TestMethod]
         [Description("Same handler implementation instance is used to handle multiple message types (instance registration).")]
         public void HandlersTest15()
         {
-			var handler = new TestDualHandler();
+            var handler = new TestDualHandler();
 
             var serviceProvider =
                 new ServiceCollection()
@@ -312,12 +312,12 @@ namespace IDeliverable.Utils.Core.Tests
                     .BuildServiceProvider();
 
             var handler1 = serviceProvider.GetRequiredService<IHandler<Message1>>();
-			var handler2 = serviceProvider.GetRequiredService<IHandler<Message2>>();
+            var handler2 = serviceProvider.GetRequiredService<IHandler<Message2>>();
 
             Assert.AreSame<object>(handler1, handler2);
         }
 
-		[TestMethod]
+        [TestMethod]
         [Description("Same handler implementation instance is used to handle multiple message types (type registration).")]
         public void HandlersTest16()
         {
@@ -327,22 +327,22 @@ namespace IDeliverable.Utils.Core.Tests
                     .BuildServiceProvider();
 
             var handler1 = serviceProvider.GetRequiredService<IHandler<Message1>>();
-			var handler2 = serviceProvider.GetRequiredService<IHandler<Message2>>();
+            var handler2 = serviceProvider.GetRequiredService<IHandler<Message2>>();
 
             Assert.AreSame<object>(handler1, handler2);
         }
 
-		[TestMethod]
+        [TestMethod]
         [Description("Handler implementation factory is called once per handled message type.")]
         public void HandlersTest17()
         {
-			var numInvocations = 0;
+            var numInvocations = 0;
 
-			TestDualHandler handlerFactory(IServiceProvider serviceProvider)
-			{
-				numInvocations++;
-				return new();
-			}
+            TestDualHandler handlerFactory(IServiceProvider serviceProvider)
+            {
+                numInvocations++;
+                return new();
+            }
 
             var serviceProvider =
                 new ServiceCollection()
@@ -350,9 +350,9 @@ namespace IDeliverable.Utils.Core.Tests
                     .BuildServiceProvider();
 
             var handler1 = serviceProvider.GetRequiredService<IHandler<Message1>>();
-			var handler2 = serviceProvider.GetRequiredService<IHandler<Message2>>();
+            var handler2 = serviceProvider.GetRequiredService<IHandler<Message2>>();
 
-			Assert.AreEqual(expected: 2, numInvocations);
+            Assert.AreEqual(expected: 2, numInvocations);
             Assert.AreNotSame<object>(handler1, handler2);
         }
 
@@ -399,10 +399,10 @@ namespace IDeliverable.Utils.Core.Tests
             }
         }
 
-		public class TestDualHandler : IHandler<Message1>, IHandler<Message2>
+        public class TestDualHandler : IHandler<Message1>, IHandler<Message2>
         {
             public Message1 HandledMessage1 { get; private set; }
-			public Message2 HandledMessage2 { get; private set; }
+            public Message2 HandledMessage2 { get; private set; }
 
             public Task HandleAsync(Message1 message, CancellationToken cancellationToken)
             {
@@ -417,7 +417,7 @@ namespace IDeliverable.Utils.Core.Tests
             }
         }
 
-		public class Message1 { }
-		public class Message2 { }
+        public class Message1 { }
+        public class Message2 { }
     }
 }

--- a/IDeliverable.Utils.Core.Tests/IDeliverable.Utils.Core.Tests.csproj
+++ b/IDeliverable.Utils.Core.Tests/IDeliverable.Utils.Core.Tests.csproj
@@ -2,17 +2,17 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/IDeliverable.Utils.Core/Handlers/ServiceCollectionExtensions.cs
+++ b/IDeliverable.Utils.Core/Handlers/ServiceCollectionExtensions.cs
@@ -6,82 +6,174 @@ using IDeliverable.Utils.Core.Handlers;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
-    public static partial class ServiceCollectionExtensions
-    {
-		/// <remarks>This registration method is idempotent; if the same <typeparamref name="TImplementation"/> type has already been registered as a handler it will not be registered again.</remarks>
-        public static IServiceCollection AddHandler<TImplementation>(this IServiceCollection services) where TImplementation : class
-        {
-            foreach (var handlerInterface in GetHandlerInterfaces<TImplementation>())
-            {
-				if (!services.Any(x => x.ServiceType == handlerInterface && x.ImplementationType == typeof(TImplementation)))
-				{
-					services.AddSingleton(handlerInterface, typeof(TImplementation));
-				}
-            }
+	public static partial class ServiceCollectionExtensions
+	{
+		/// <summary>
+		/// Registers a singleton service to be resolved and invoked to handle messages of type <typeparamref name="TMessage"/>.
+		/// </summary>
+		/// <remarks>
+		/// If the same <typeparamref name="TImplementation"/> type has already been registered, it will not be registered again.
+		/// The resulting service registration will be resolvable both as <typeparamref name="TImplementation"/> and as any
+		/// <see cref="IHandler{TMessage}"/> interfaces it implements.
+		/// If <typeparamref name="TImplementation"/> implements <see cref="IHandler{TMessage}"/> for several TMessage types, a single
+		/// <typeparamref name="TImplementation"/> instance will handle messages of all types.
+		/// </remarks>
+		/// 
+		public static IServiceCollection AddHandler<TImplementation>(this IServiceCollection services) where TImplementation : class
+		{
+			GetHandlerInterfaces<TImplementation>();
 
-            return services;
-        }
+			if (!services.Any(x => x.ServiceType == typeof(TImplementation) && x.ImplementationType == typeof(TImplementation)))
+			{
+				services.AddSingleton<TImplementation>();
+			}
 
-		/// <remarks>This registration method is idempotent; if the same <paramref name="implementationInstance"/> instance has already been registered as a handler it will not be registered again.</remarks>
-        public static IServiceCollection AddHandler<TImplementation>(this IServiceCollection services, TImplementation implementationInstance) where TImplementation : class
-        {
-            foreach (var handlerInterface in GetHandlerInterfaces<TImplementation>())
-            {
-				if (!services.Any(x => x.ServiceType == handlerInterface && x.ImplementationInstance == implementationInstance))
-				{
-					services.AddSingleton(handlerInterface, implementationInstance);
-				}
-            }
+			services.AddHandler(serviceProvider => serviceProvider.GetRequiredService<TImplementation>());
 
-            return services;
-        }
+			return services;
+		}
 
-		/// <remarks>This registration method is idempotent; if the same <paramref name="implementationFactory"/> delegate has already been registered it will not be registered again.</remarks>
-        public static IServiceCollection AddHandler<TImplementation>(this IServiceCollection services, Func<IServiceProvider, TImplementation> implementationFactory) where TImplementation : class
-        {
-            foreach (var handlerInterface in GetHandlerInterfaces<TImplementation>())
-            {
+		/// <summary>
+		/// Registers a singleton instance to be invoked to handle messages of type <typeparamref name="TMessage"/>.
+		/// </summary>
+		/// <remarks>
+		/// If the same <paramref name="implementationInstance"/> instance has already been registered, it will not be registered again.
+		/// The <paramref name="implementationInstance"/> will be resolvable both as <typeparamref name="TImplementation"/> and as any
+		/// <see cref="IHandler{TMessage}"/> interfaces it implements.
+		/// If <typeparamref name="TImplementation"/> implements <see cref="IHandler{TMessage}"/> for several TMessage types, the same
+		/// <paramref name="implementationInstance"/> instance will handle messages of all types.
+		/// </remarks>
+		public static IServiceCollection AddHandler<TImplementation>(this IServiceCollection services, TImplementation implementationInstance) where TImplementation : class
+		{
+			GetHandlerInterfaces<TImplementation>();
+
+			if (!services.Any(x => x.ServiceType == typeof(TImplementation) && x.ImplementationInstance == implementationInstance))
+			{
+				services.AddSingleton(implementationInstance);
+			}
+
+			services.AddHandler(serviceProvider => serviceProvider.GetRequiredService<TImplementation>());
+
+			return services;
+		}
+
+		/// <summary>
+		/// Registers a factory to be used to resolve instance to handle messages of type <typeparamref name="TMessage"/>.
+		/// </summary>
+		/// <remarks>
+		/// If the same <paramref name="implementationFactory"/> delegate has already been registered, it will not be registered again.
+		/// If <typeparamref name="TImplementation"/> implements <see cref="IHandler{TMessage}"/> for several TMessage types, the same
+		/// <paramref name="implementationFactory"/> will be called once per message type and may return the same
+		/// <typeparamref name="TImplementation"/> instance or different instances.
+		/// </remarks>
+		public static IServiceCollection AddHandler<TImplementation>(this IServiceCollection services, Func<IServiceProvider, TImplementation> implementationFactory) where TImplementation : class
+		{
+			foreach (var handlerInterface in GetHandlerInterfaces<TImplementation>())
+			{
 				if (!services.Any(x => x.ServiceType == handlerInterface && x.ImplementationFactory == implementationFactory))
 				{
 					services.AddSingleton(handlerInterface, implementationFactory);
 				}
-            }
+			}
 
-            return services;
-        }
+			return services;
+		}
 
-        public static IServiceCollection AddHandler<TMessage>(this IServiceCollection services, Action<TMessage> handler)
-        {
-            var delegateHandler = new DelegateHandler<TMessage>(handler);
+		/// <summary>
+		/// Adds a delegate to be invoked to handle messages of type <typeparamref name="TMessage"/>.
+		/// </summary>
+		/// <remarks>
+		/// This registration method is not idempotent; calling it twice with the same <paramref name="handler"/> delegate will result in
+		/// that delegate being invoked twice for every message of type <typeparamref name="TMessage"/>.
+		/// </remarks>
+		public static IServiceCollection AddHandler<TMessage>(this IServiceCollection services, Action<TMessage> handler)
+		{
+			return services.AddSingleton<IHandler<TMessage>>(new DelegateHandler<TMessage>(handler));
+		}
 
-            return services.AddSingleton<IHandler<TMessage>>(delegateHandler);
-        }
+		/// <summary>
+		/// Adds an async delegate to be invoked to handle messages of type <typeparamref name="TMessage"/>.
+		/// </summary>
+		/// <remarks>
+		/// This registration method is not idempotent; calling it twice with the same <paramref name="handler"/> delegate will result in
+		/// that delegate being invoked twice for every message of type <typeparamref name="TMessage"/>.
+		/// </remarks>
+		public static IServiceCollection AddHandler<TMessage>(this IServiceCollection services, Func<TMessage, Task> handler)
+		{
+			return services.AddSingleton<IHandler<TMessage>>(new DelegateHandler<TMessage>(handler));
+		}
 
-        public static IServiceCollection AddHandler<TMessage>(this IServiceCollection services, Func<TMessage, Task> handler)
-        {
-            var delegateHandler = new DelegateHandler<TMessage>(handler);
+		/// <summary>
+		/// Adds a cancellable delegate to be invoked to handle messages of type <typeparamref name="TMessage"/>.
+		/// </summary>
+		/// <remarks>
+		/// This registration method is not idempotent; calling it twice with the same <paramref name="handler"/> delegate will result in
+		/// that delegate being invoked twice for every message of type <typeparamref name="TMessage"/>.
+		/// </remarks>
+		public static IServiceCollection AddHandler<TMessage>(this IServiceCollection services, Action<TMessage, CancellationToken> handler)
+		{
+            return services.AddSingleton<IHandler<TMessage>>(new DelegateHandler<TMessage>(handler));
+		}
 
-            return services.AddSingleton<IHandler<TMessage>>(delegateHandler);
-        }
+		/// <summary>
+		/// Adds an async cancellable delegate to be invoked to handle messages of type <typeparamref name="TMessage"/>.
+		/// </summary>
+		/// <remarks>
+		/// This registration method is not idempotent; calling it twice with the same <paramref name="handler"/> delegate will result in
+		/// that delegate being invoked twice for every message of type <typeparamref name="TMessage"/>.
+		/// </remarks>
+		public static IServiceCollection AddHandler<TMessage>(this IServiceCollection services, Func<TMessage, CancellationToken, Task> handler)
+		{
+            return services.AddSingleton<IHandler<TMessage>>(new DelegateHandler<TMessage>(handler));
+		}
 
-        public static IServiceCollection AddHandler<TMessage>(this IServiceCollection services, Action<TMessage, CancellationToken> handler)
-        {
-            var delegateHandler = new DelegateHandler<TMessage>(handler);
+		/// <summary>
+		/// Adds a delegate to be invoked with an <see cref="IServiceProvider"/> instance to handle messages of type <typeparamref name="TMessage"/>.
+		/// </summary>
+		/// <remarks>
+		/// This registration method is not idempotent; calling it twice with the same <paramref name="handler"/> delegate will result in
+		/// that delegate being invoked twice for every message of type <typeparamref name="TMessage"/>.
+		/// </remarks>
+		public static IServiceCollection AddHandler<TMessage>(this IServiceCollection services, Action<IServiceProvider, TMessage> handler)
+		{
+			return services.AddSingleton<IHandler<TMessage>>(serviceProvider => new DelegateHandler<TMessage>(message => handler(serviceProvider, message)));
+		}
 
-            return services.AddSingleton<IHandler<TMessage>>(delegateHandler);
-        }
+		/// <summary>
+		/// Adds an async delegate to be invoked with an <see cref="IServiceProvider"/> instance to handle messages of type <typeparamref name="TMessage"/>.
+		/// </summary>
+		/// <remarks>
+		/// This registration method is not idempotent; calling it twice with the same <paramref name="handler"/> delegate will result in
+		/// that delegate being invoked twice for every message of type <typeparamref name="TMessage"/>.
+		/// </remarks>
+		public static IServiceCollection AddHandler<TMessage>(this IServiceCollection services, Func<IServiceProvider, TMessage, Task> handler)
+		{
+			return services.AddSingleton<IHandler<TMessage>>(serviceProvider => new DelegateHandler<TMessage>(message => handler(serviceProvider, message)));
+		}
 
-        public static IServiceCollection AddHandler<TMessage>(this IServiceCollection services, Func<TMessage, CancellationToken, Task> handler)
-        {
-            var delegateHandler = new DelegateHandler<TMessage>(handler);
+		/// <summary>
+		/// Adds a cancellable delegate to be invoked with an <see cref="IServiceProvider"/> instance to handle messages of type <typeparamref name="TMessage"/>.
+		/// </summary>
+		/// <remarks>
+		/// This registration method is not idempotent; calling it twice with the same <paramref name="handler"/> delegate will result in
+		/// that delegate being invoked twice for every message of type <typeparamref name="TMessage"/>.
+		/// </remarks>
+		public static IServiceCollection AddHandler<TMessage>(this IServiceCollection services, Action<IServiceProvider, TMessage, CancellationToken> handler)
+		{
+			return services.AddSingleton<IHandler<TMessage>>(serviceProvider => new DelegateHandler<TMessage>((message, cancellationToken) => handler(serviceProvider, message, cancellationToken)));
+		}
 
-            return services.AddSingleton<IHandler<TMessage>>(delegateHandler);
-        }
-
-        public static IServiceCollection AddHandler<TMessage>(this IServiceCollection services, Func<IServiceProvider, TMessage, CancellationToken, Task> handler)
-        {
-            return services.AddSingleton<IHandler<TMessage>>((services) => new DelegateHandler<TMessage>((mesage, cancellationToken) => handler(services, mesage, cancellationToken)));
-        }
+		/// <summary>
+		/// Adds an async cancellable delegate to be invoked with an <see cref="IServiceProvider"/> instance to handle messages of type <typeparamref name="TMessage"/>.
+		/// </summary>
+		/// <remarks>
+		/// This registration method is not idempotent; calling it twice with the same <paramref name="handler"/> delegate will result in
+		/// that delegate being invoked twice for every message of type <typeparamref name="TMessage"/>.
+		/// </remarks>
+		public static IServiceCollection AddHandler<TMessage>(this IServiceCollection services, Func<IServiceProvider, TMessage, CancellationToken, Task> handler)
+		{
+			return services.AddSingleton<IHandler<TMessage>>(serviceProvider => new DelegateHandler<TMessage>((message, cancellationToken) => handler(serviceProvider, message, cancellationToken)));
+		}
 
 		private static Type[] GetHandlerInterfaces<TImplementation>()
 		{
@@ -96,6 +188,6 @@ namespace Microsoft.Extensions.DependencyInjection
 			}
 
 			return handlerInterfaces;
-		} 
-    }
+		}
+	}
 }

--- a/IDeliverable.Utils.Core/Handlers/ServiceCollectionExtensions.cs
+++ b/IDeliverable.Utils.Core/Handlers/ServiceCollectionExtensions.cs
@@ -6,188 +6,188 @@ using IDeliverable.Utils.Core.Handlers;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
-	public static partial class ServiceCollectionExtensions
-	{
-		/// <summary>
-		/// Registers a singleton service to be resolved and invoked to handle messages of type <typeparamref name="TMessage"/>.
-		/// </summary>
-		/// <remarks>
-		/// If the same <typeparamref name="TImplementation"/> type has already been registered, it will not be registered again.
-		/// The resulting service registration will be resolvable both as <typeparamref name="TImplementation"/> and as any
-		/// <see cref="IHandler{TMessage}"/> interfaces it implements.
-		/// If <typeparamref name="TImplementation"/> implements <see cref="IHandler{TMessage}"/> for several TMessage types, a single
-		/// <typeparamref name="TImplementation"/> instance will handle messages of all types.
-		/// </remarks>
-		/// 
-		public static IServiceCollection AddHandler<TImplementation>(this IServiceCollection services) where TImplementation : class
-		{
-			GetHandlerInterfaces<TImplementation>();
+    public static partial class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Registers a singleton service to be resolved and invoked to handle messages of type <typeparamref name="TMessage"/>.
+        /// </summary>
+        /// <remarks>
+        /// If the same <typeparamref name="TImplementation"/> type has already been registered, it will not be registered again.
+        /// The resulting service registration will be resolvable both as <typeparamref name="TImplementation"/> and as any
+        /// <see cref="IHandler{TMessage}"/> interfaces it implements.
+        /// If <typeparamref name="TImplementation"/> implements <see cref="IHandler{TMessage}"/> for several TMessage types, a single
+        /// <typeparamref name="TImplementation"/> instance will handle messages of all types.
+        /// </remarks>
+        /// 
+        public static IServiceCollection AddHandler<TImplementation>(this IServiceCollection services) where TImplementation : class
+        {
+            GetHandlerInterfaces<TImplementation>();
 
-			if (!services.Any(x => x.ServiceType == typeof(TImplementation) && x.ImplementationType == typeof(TImplementation)))
-			{
-				services.AddSingleton<TImplementation>();
-			}
+            if (!services.Any(x => x.ServiceType == typeof(TImplementation) && x.ImplementationType == typeof(TImplementation)))
+            {
+                services.AddSingleton<TImplementation>();
+            }
 
-			services.AddHandler(serviceProvider => serviceProvider.GetRequiredService<TImplementation>());
+            services.AddHandler(serviceProvider => serviceProvider.GetRequiredService<TImplementation>());
 
-			return services;
-		}
+            return services;
+        }
 
-		/// <summary>
-		/// Registers a singleton instance to be invoked to handle messages of type <typeparamref name="TMessage"/>.
-		/// </summary>
-		/// <remarks>
-		/// If the same <paramref name="implementationInstance"/> instance has already been registered, it will not be registered again.
-		/// The <paramref name="implementationInstance"/> will be resolvable both as <typeparamref name="TImplementation"/> and as any
-		/// <see cref="IHandler{TMessage}"/> interfaces it implements.
-		/// If <typeparamref name="TImplementation"/> implements <see cref="IHandler{TMessage}"/> for several TMessage types, the same
-		/// <paramref name="implementationInstance"/> instance will handle messages of all types.
-		/// </remarks>
-		public static IServiceCollection AddHandler<TImplementation>(this IServiceCollection services, TImplementation implementationInstance) where TImplementation : class
-		{
-			GetHandlerInterfaces<TImplementation>();
+        /// <summary>
+        /// Registers a singleton instance to be invoked to handle messages of type <typeparamref name="TMessage"/>.
+        /// </summary>
+        /// <remarks>
+        /// If the same <paramref name="implementationInstance"/> instance has already been registered, it will not be registered again.
+        /// The <paramref name="implementationInstance"/> will be resolvable both as <typeparamref name="TImplementation"/> and as any
+        /// <see cref="IHandler{TMessage}"/> interfaces it implements.
+        /// If <typeparamref name="TImplementation"/> implements <see cref="IHandler{TMessage}"/> for several TMessage types, the same
+        /// <paramref name="implementationInstance"/> instance will handle messages of all types.
+        /// </remarks>
+        public static IServiceCollection AddHandler<TImplementation>(this IServiceCollection services, TImplementation implementationInstance) where TImplementation : class
+        {
+            GetHandlerInterfaces<TImplementation>();
 
-			if (!services.Any(x => x.ServiceType == typeof(TImplementation) && x.ImplementationInstance == implementationInstance))
-			{
-				services.AddSingleton(implementationInstance);
-			}
+            if (!services.Any(x => x.ServiceType == typeof(TImplementation) && x.ImplementationInstance == implementationInstance))
+            {
+                services.AddSingleton(implementationInstance);
+            }
 
-			services.AddHandler(serviceProvider => serviceProvider.GetRequiredService<TImplementation>());
+            services.AddHandler(serviceProvider => serviceProvider.GetRequiredService<TImplementation>());
 
-			return services;
-		}
+            return services;
+        }
 
-		/// <summary>
-		/// Registers a factory to be used to resolve instance to handle messages of type <typeparamref name="TMessage"/>.
-		/// </summary>
-		/// <remarks>
-		/// If the same <paramref name="implementationFactory"/> delegate has already been registered, it will not be registered again.
-		/// If <typeparamref name="TImplementation"/> implements <see cref="IHandler{TMessage}"/> for several TMessage types, the same
-		/// <paramref name="implementationFactory"/> will be called once per message type and may return the same
-		/// <typeparamref name="TImplementation"/> instance or different instances.
-		/// </remarks>
-		public static IServiceCollection AddHandler<TImplementation>(this IServiceCollection services, Func<IServiceProvider, TImplementation> implementationFactory) where TImplementation : class
-		{
-			foreach (var handlerInterface in GetHandlerInterfaces<TImplementation>())
-			{
-				if (!services.Any(x => x.ServiceType == handlerInterface && x.ImplementationFactory == implementationFactory))
-				{
-					services.AddSingleton(handlerInterface, implementationFactory);
-				}
-			}
+        /// <summary>
+        /// Registers a factory to be used to resolve instance to handle messages of type <typeparamref name="TMessage"/>.
+        /// </summary>
+        /// <remarks>
+        /// If the same <paramref name="implementationFactory"/> delegate has already been registered, it will not be registered again.
+        /// If <typeparamref name="TImplementation"/> implements <see cref="IHandler{TMessage}"/> for several TMessage types, the same
+        /// <paramref name="implementationFactory"/> will be called once per message type and may return the same
+        /// <typeparamref name="TImplementation"/> instance or different instances.
+        /// </remarks>
+        public static IServiceCollection AddHandler<TImplementation>(this IServiceCollection services, Func<IServiceProvider, TImplementation> implementationFactory) where TImplementation : class
+        {
+            foreach (var handlerInterface in GetHandlerInterfaces<TImplementation>())
+            {
+                if (!services.Any(x => x.ServiceType == handlerInterface && x.ImplementationFactory == implementationFactory))
+                {
+                    services.AddSingleton(handlerInterface, implementationFactory);
+                }
+            }
 
-			return services;
-		}
+            return services;
+        }
 
-		/// <summary>
-		/// Adds a delegate to be invoked to handle messages of type <typeparamref name="TMessage"/>.
-		/// </summary>
-		/// <remarks>
-		/// This registration method is not idempotent; calling it twice with the same <paramref name="handler"/> delegate will result in
-		/// that delegate being invoked twice for every message of type <typeparamref name="TMessage"/>.
-		/// </remarks>
-		public static IServiceCollection AddHandler<TMessage>(this IServiceCollection services, Action<TMessage> handler)
-		{
-			return services.AddSingleton<IHandler<TMessage>>(new DelegateHandler<TMessage>(handler));
-		}
-
-		/// <summary>
-		/// Adds an async delegate to be invoked to handle messages of type <typeparamref name="TMessage"/>.
-		/// </summary>
-		/// <remarks>
-		/// This registration method is not idempotent; calling it twice with the same <paramref name="handler"/> delegate will result in
-		/// that delegate being invoked twice for every message of type <typeparamref name="TMessage"/>.
-		/// </remarks>
-		public static IServiceCollection AddHandler<TMessage>(this IServiceCollection services, Func<TMessage, Task> handler)
-		{
-			return services.AddSingleton<IHandler<TMessage>>(new DelegateHandler<TMessage>(handler));
-		}
-
-		/// <summary>
-		/// Adds a cancellable delegate to be invoked to handle messages of type <typeparamref name="TMessage"/>.
-		/// </summary>
-		/// <remarks>
-		/// This registration method is not idempotent; calling it twice with the same <paramref name="handler"/> delegate will result in
-		/// that delegate being invoked twice for every message of type <typeparamref name="TMessage"/>.
-		/// </remarks>
-		public static IServiceCollection AddHandler<TMessage>(this IServiceCollection services, Action<TMessage, CancellationToken> handler)
-		{
+        /// <summary>
+        /// Adds a delegate to be invoked to handle messages of type <typeparamref name="TMessage"/>.
+        /// </summary>
+        /// <remarks>
+        /// This registration method is not idempotent; calling it twice with the same <paramref name="handler"/> delegate will result in
+        /// that delegate being invoked twice for every message of type <typeparamref name="TMessage"/>.
+        /// </remarks>
+        public static IServiceCollection AddHandler<TMessage>(this IServiceCollection services, Action<TMessage> handler)
+        {
             return services.AddSingleton<IHandler<TMessage>>(new DelegateHandler<TMessage>(handler));
-		}
+        }
 
-		/// <summary>
-		/// Adds an async cancellable delegate to be invoked to handle messages of type <typeparamref name="TMessage"/>.
-		/// </summary>
-		/// <remarks>
-		/// This registration method is not idempotent; calling it twice with the same <paramref name="handler"/> delegate will result in
-		/// that delegate being invoked twice for every message of type <typeparamref name="TMessage"/>.
-		/// </remarks>
-		public static IServiceCollection AddHandler<TMessage>(this IServiceCollection services, Func<TMessage, CancellationToken, Task> handler)
-		{
+        /// <summary>
+        /// Adds an async delegate to be invoked to handle messages of type <typeparamref name="TMessage"/>.
+        /// </summary>
+        /// <remarks>
+        /// This registration method is not idempotent; calling it twice with the same <paramref name="handler"/> delegate will result in
+        /// that delegate being invoked twice for every message of type <typeparamref name="TMessage"/>.
+        /// </remarks>
+        public static IServiceCollection AddHandler<TMessage>(this IServiceCollection services, Func<TMessage, Task> handler)
+        {
             return services.AddSingleton<IHandler<TMessage>>(new DelegateHandler<TMessage>(handler));
-		}
+        }
 
-		/// <summary>
-		/// Adds a delegate to be invoked with an <see cref="IServiceProvider"/> instance to handle messages of type <typeparamref name="TMessage"/>.
-		/// </summary>
-		/// <remarks>
-		/// This registration method is not idempotent; calling it twice with the same <paramref name="handler"/> delegate will result in
-		/// that delegate being invoked twice for every message of type <typeparamref name="TMessage"/>.
-		/// </remarks>
-		public static IServiceCollection AddHandler<TMessage>(this IServiceCollection services, Action<IServiceProvider, TMessage> handler)
-		{
-			return services.AddSingleton<IHandler<TMessage>>(serviceProvider => new DelegateHandler<TMessage>(message => handler(serviceProvider, message)));
-		}
+        /// <summary>
+        /// Adds a cancellable delegate to be invoked to handle messages of type <typeparamref name="TMessage"/>.
+        /// </summary>
+        /// <remarks>
+        /// This registration method is not idempotent; calling it twice with the same <paramref name="handler"/> delegate will result in
+        /// that delegate being invoked twice for every message of type <typeparamref name="TMessage"/>.
+        /// </remarks>
+        public static IServiceCollection AddHandler<TMessage>(this IServiceCollection services, Action<TMessage, CancellationToken> handler)
+        {
+            return services.AddSingleton<IHandler<TMessage>>(new DelegateHandler<TMessage>(handler));
+        }
 
-		/// <summary>
-		/// Adds an async delegate to be invoked with an <see cref="IServiceProvider"/> instance to handle messages of type <typeparamref name="TMessage"/>.
-		/// </summary>
-		/// <remarks>
-		/// This registration method is not idempotent; calling it twice with the same <paramref name="handler"/> delegate will result in
-		/// that delegate being invoked twice for every message of type <typeparamref name="TMessage"/>.
-		/// </remarks>
-		public static IServiceCollection AddHandler<TMessage>(this IServiceCollection services, Func<IServiceProvider, TMessage, Task> handler)
-		{
-			return services.AddSingleton<IHandler<TMessage>>(serviceProvider => new DelegateHandler<TMessage>(message => handler(serviceProvider, message)));
-		}
+        /// <summary>
+        /// Adds an async cancellable delegate to be invoked to handle messages of type <typeparamref name="TMessage"/>.
+        /// </summary>
+        /// <remarks>
+        /// This registration method is not idempotent; calling it twice with the same <paramref name="handler"/> delegate will result in
+        /// that delegate being invoked twice for every message of type <typeparamref name="TMessage"/>.
+        /// </remarks>
+        public static IServiceCollection AddHandler<TMessage>(this IServiceCollection services, Func<TMessage, CancellationToken, Task> handler)
+        {
+            return services.AddSingleton<IHandler<TMessage>>(new DelegateHandler<TMessage>(handler));
+        }
 
-		/// <summary>
-		/// Adds a cancellable delegate to be invoked with an <see cref="IServiceProvider"/> instance to handle messages of type <typeparamref name="TMessage"/>.
-		/// </summary>
-		/// <remarks>
-		/// This registration method is not idempotent; calling it twice with the same <paramref name="handler"/> delegate will result in
-		/// that delegate being invoked twice for every message of type <typeparamref name="TMessage"/>.
-		/// </remarks>
-		public static IServiceCollection AddHandler<TMessage>(this IServiceCollection services, Action<IServiceProvider, TMessage, CancellationToken> handler)
-		{
-			return services.AddSingleton<IHandler<TMessage>>(serviceProvider => new DelegateHandler<TMessage>((message, cancellationToken) => handler(serviceProvider, message, cancellationToken)));
-		}
+        /// <summary>
+        /// Adds a delegate to be invoked with an <see cref="IServiceProvider"/> instance to handle messages of type <typeparamref name="TMessage"/>.
+        /// </summary>
+        /// <remarks>
+        /// This registration method is not idempotent; calling it twice with the same <paramref name="handler"/> delegate will result in
+        /// that delegate being invoked twice for every message of type <typeparamref name="TMessage"/>.
+        /// </remarks>
+        public static IServiceCollection AddHandler<TMessage>(this IServiceCollection services, Action<IServiceProvider, TMessage> handler)
+        {
+            return services.AddSingleton<IHandler<TMessage>>(serviceProvider => new DelegateHandler<TMessage>(message => handler(serviceProvider, message)));
+        }
 
-		/// <summary>
-		/// Adds an async cancellable delegate to be invoked with an <see cref="IServiceProvider"/> instance to handle messages of type <typeparamref name="TMessage"/>.
-		/// </summary>
-		/// <remarks>
-		/// This registration method is not idempotent; calling it twice with the same <paramref name="handler"/> delegate will result in
-		/// that delegate being invoked twice for every message of type <typeparamref name="TMessage"/>.
-		/// </remarks>
-		public static IServiceCollection AddHandler<TMessage>(this IServiceCollection services, Func<IServiceProvider, TMessage, CancellationToken, Task> handler)
-		{
-			return services.AddSingleton<IHandler<TMessage>>(serviceProvider => new DelegateHandler<TMessage>((message, cancellationToken) => handler(serviceProvider, message, cancellationToken)));
-		}
+        /// <summary>
+        /// Adds an async delegate to be invoked with an <see cref="IServiceProvider"/> instance to handle messages of type <typeparamref name="TMessage"/>.
+        /// </summary>
+        /// <remarks>
+        /// This registration method is not idempotent; calling it twice with the same <paramref name="handler"/> delegate will result in
+        /// that delegate being invoked twice for every message of type <typeparamref name="TMessage"/>.
+        /// </remarks>
+        public static IServiceCollection AddHandler<TMessage>(this IServiceCollection services, Func<IServiceProvider, TMessage, Task> handler)
+        {
+            return services.AddSingleton<IHandler<TMessage>>(serviceProvider => new DelegateHandler<TMessage>(message => handler(serviceProvider, message)));
+        }
 
-		private static Type[] GetHandlerInterfaces<TImplementation>()
-		{
-			var handlerInterfaces =
-				typeof(TImplementation).GetInterfaces()
-					.Where(x => x.IsConstructedGenericType && x.GetGenericTypeDefinition() == typeof(IHandler<>))
-					.ToArray();
+        /// <summary>
+        /// Adds a cancellable delegate to be invoked with an <see cref="IServiceProvider"/> instance to handle messages of type <typeparamref name="TMessage"/>.
+        /// </summary>
+        /// <remarks>
+        /// This registration method is not idempotent; calling it twice with the same <paramref name="handler"/> delegate will result in
+        /// that delegate being invoked twice for every message of type <typeparamref name="TMessage"/>.
+        /// </remarks>
+        public static IServiceCollection AddHandler<TMessage>(this IServiceCollection services, Action<IServiceProvider, TMessage, CancellationToken> handler)
+        {
+            return services.AddSingleton<IHandler<TMessage>>(serviceProvider => new DelegateHandler<TMessage>((message, cancellationToken) => handler(serviceProvider, message, cancellationToken)));
+        }
 
-			if (!handlerInterfaces.Any())
-			{
-				throw new ArgumentException($"Generic type parameter {nameof(TImplementation)} must refer to a type that implements IHandler<TMessage> for at least one TMessage type.");
-			}
+        /// <summary>
+        /// Adds an async cancellable delegate to be invoked with an <see cref="IServiceProvider"/> instance to handle messages of type <typeparamref name="TMessage"/>.
+        /// </summary>
+        /// <remarks>
+        /// This registration method is not idempotent; calling it twice with the same <paramref name="handler"/> delegate will result in
+        /// that delegate being invoked twice for every message of type <typeparamref name="TMessage"/>.
+        /// </remarks>
+        public static IServiceCollection AddHandler<TMessage>(this IServiceCollection services, Func<IServiceProvider, TMessage, CancellationToken, Task> handler)
+        {
+            return services.AddSingleton<IHandler<TMessage>>(serviceProvider => new DelegateHandler<TMessage>((message, cancellationToken) => handler(serviceProvider, message, cancellationToken)));
+        }
 
-			return handlerInterfaces;
-		}
-	}
+        private static Type[] GetHandlerInterfaces<TImplementation>()
+        {
+            var handlerInterfaces =
+                typeof(TImplementation).GetInterfaces()
+                    .Where(x => x.IsConstructedGenericType && x.GetGenericTypeDefinition() == typeof(IHandler<>))
+                    .ToArray();
+
+            if (!handlerInterfaces.Any())
+            {
+                throw new ArgumentException($"Generic type parameter {nameof(TImplementation)} must refer to a type that implements IHandler<TMessage> for at least one TMessage type.");
+            }
+
+            return handlerInterfaces;
+        }
+    }
 }

--- a/IDeliverable.Utils.Core/IDeliverable.Utils.Core.csproj
+++ b/IDeliverable.Utils.Core/IDeliverable.Utils.Core.csproj
@@ -12,19 +12,19 @@
         <PackageProjectUrl>https://github.com/IDeliverable/Utils</PackageProjectUrl>
         <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
         <PackageIconUrl>http://storage.ideliverable.com/media/Default/Logo/Logo-Icon-Color-Loud-512.png</PackageIconUrl>
-        <Version>1.3.0</Version>
-        <AssemblyVersion>1.3.0.0</AssemblyVersion>
-        <FileVersion>1.3.0.0</FileVersion>
-        <PackageReleaseNotes>Adds overload for AddHandler() that provides an IServiceProvider</PackageReleaseNotes>
+        <Version>1.4.0</Version>
+        <AssemblyVersion>1.4.0.0</AssemblyVersion>
+        <FileVersion>1.4.0.0</FileVersion>
+        <PackageReleaseNotes>Makes all AddHandler&lt;TImplementation&gt;() overloads idempotent.</PackageReleaseNotes>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.5" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.5" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
     </ItemGroup>

--- a/IDeliverable.Utils.Core/IDeliverable.Utils.Core.csproj
+++ b/IDeliverable.Utils.Core/IDeliverable.Utils.Core.csproj
@@ -16,11 +16,11 @@
         <AssemblyVersion>1.4.0.0</AssemblyVersion>
         <FileVersion>1.4.0.0</FileVersion>
         <PackageReleaseNotes>
-			Makes all AddHandler&lt;TImplementation&gt;() overloads idempotent.
-			Adds single-instance handling of multiple message types.
-			Adds xmldoc comments to all AddHandler() methods.
-			Adds missing AddHandler&lt;TMessage&gt;() overloads.
-		</PackageReleaseNotes>
+            Makes all AddHandler&lt;TImplementation&gt;() overloads idempotent.
+            Adds single-instance handling of multiple message types.
+            Adds xmldoc comments to all AddHandler() methods.
+            Adds missing AddHandler&lt;TMessage&gt;() overloads.
+        </PackageReleaseNotes>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
         <LangVersion>latest</LangVersion>

--- a/IDeliverable.Utils.Core/IDeliverable.Utils.Core.csproj
+++ b/IDeliverable.Utils.Core/IDeliverable.Utils.Core.csproj
@@ -15,7 +15,12 @@
         <Version>1.4.0</Version>
         <AssemblyVersion>1.4.0.0</AssemblyVersion>
         <FileVersion>1.4.0.0</FileVersion>
-        <PackageReleaseNotes>Makes all AddHandler&lt;TImplementation&gt;() overloads idempotent.</PackageReleaseNotes>
+        <PackageReleaseNotes>
+			Makes all AddHandler&lt;TImplementation&gt;() overloads idempotent.
+			Adds single-instance handling of multiple message types.
+			Adds xmldoc comments to all AddHandler() methods.
+			Adds missing AddHandler&lt;TMessage&gt;() overloads.
+		</PackageReleaseNotes>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
         <LangVersion>latest</LangVersion>


### PR DESCRIPTION
- Makes all `AddHandler<TImplementation>()` overloads idempotent
- Adds single-instance handling of multiple message types
- Adds xmldoc comments to all `AddHandler()` methods
- Adds missing `AddHandler<TMessage>()` overloads
- Adds test cases to cover new expectations
- Updates `Microsoft.Extensions.*` dependencies to `8.0.0`
- Updates test project dependencies and target framework
- Bumps version to `1.4.0`